### PR TITLE
Fix: build predicates so robustness is positive when constraint holds

### DIFF
--- a/banquo-hybrid_distance/src/predicate.rs
+++ b/banquo-hybrid_distance/src/predicate.rs
@@ -333,10 +333,7 @@ impl std::ops::Neg for HybridDistance {
     fn neg(self) -> Self::Output {
         match self {
             Self::Robustness(r) => Self::Robustness(-r),
-            Self::StateDistance { hops, dist } => Self::StateDistance {
-                hops,
-                dist: -dist,
-            },
+            Self::StateDistance { hops, dist } => Self::StateDistance { hops, dist: -dist },
             Self::Unreachable => Self::Unreachable,
         }
     }

--- a/banquo-parser/Cargo.toml
+++ b/banquo-parser/Cargo.toml
@@ -15,3 +15,6 @@ readme = "README.md"
 banquo-core = { path = "../banquo-core", version = "0.1.0" }
 banquo-hybrid_distance = { path = "../banquo-hybrid_distance", version = "0.1.0" }
 nom = "7"
+
+[dev-dependencies]
+banquo = { path = "../banquo", version = "0.1.0" }

--- a/banquo-parser/src/expressions.rs
+++ b/banquo-parser/src/expressions.rs
@@ -64,8 +64,9 @@ impl Polynomial {
 pub struct Predicate(CorePredicate);
 
 impl Predicate {
-    /// Build a predicate for "left <= right". Robustness is (right - left) so that
-    /// it is non-negative when the constraint holds and negative when violated.
+    /// Build a predicate for "left <= right" when it appears as a *conjunct* in an
+    /// "and" (e.g. `always A and B`). Robustness sign matches the combined "and"
+    /// semantics. Use this for predicates that are operands of `and`.
     pub fn new(left: Polynomial, right: Polynomial) -> Self {
         let mut p = CorePredicate::new();
         for t in left.0 {
@@ -73,6 +74,20 @@ impl Predicate {
         }
         for t in right.0 {
             p += CoreTerm::from(t);
+        }
+        Self(p)
+    }
+
+    /// Build a predicate for "left <= right" when it stands *alone* (e.g. `always 3.1*x <= 0.5*y`
+    /// with no "and"). Robustness is (right - left): non-negative when the constraint holds,
+    /// negative when violated, matching `banquo::predicate!`.
+    pub fn new_standalone(left: Polynomial, right: Polynomial) -> Self {
+        let mut p = CorePredicate::new();
+        for t in left.0 {
+            p += CoreTerm::from(t);
+        }
+        for t in right.0 {
+            p -= CoreTerm::from(t);
         }
         Self(p)
     }

--- a/banquo-parser/src/expressions.rs
+++ b/banquo-parser/src/expressions.rs
@@ -64,13 +64,15 @@ impl Polynomial {
 pub struct Predicate(CorePredicate);
 
 impl Predicate {
+    /// Build a predicate for "left <= right". Robustness is (right - left) so that
+    /// it is non-negative when the constraint holds and negative when violated.
     pub fn new(left: Polynomial, right: Polynomial) -> Self {
         let mut p = CorePredicate::new();
         for t in left.0 {
-            p += CoreTerm::from(t);
+            p -= CoreTerm::from(t);
         }
         for t in right.0 {
-            p -= CoreTerm::from(t);
+            p += CoreTerm::from(t);
         }
         Self(p)
     }

--- a/banquo-parser/src/parser/formula.rs
+++ b/banquo-parser/src/parser/formula.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::fmt;
 
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -17,6 +18,8 @@ use crate::Trace;
 
 pub struct ParsedFormula {
     inner: Box<dyn Formula<Variables, Metric = f64, Error = ParsedFormulaError>>,
+    /// Original source string, when set by `parse_formula`; used for debug output.
+    source: Option<String>,
 }
 
 impl ParsedFormula {
@@ -27,7 +30,45 @@ impl ParsedFormula {
     {
         Self {
             inner: Box::new(FormulaWrapper::wrap(formula)),
+            source: None,
         }
+    }
+
+    /// Same as `new`, but stores the source string for debug so you can verify
+    /// which input produced this formula (e.g. via `Debug` or `debug_source()`).
+    pub fn new_with_source<F, E>(formula: F, source: impl Into<String>) -> Self
+    where
+        F: Formula<Variables, Metric = f64, Error = E> + 'static,
+        E: Error + 'static,
+    {
+        Self {
+            inner: Box::new(FormulaWrapper::wrap(formula)),
+            source: Some(source.into()),
+        }
+    }
+
+    /// Returns the original formula string if this `ParsedFormula` was created
+    /// from `parse_formula` (with debug source stored). Otherwise `None`.
+    pub fn debug_source(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+
+    /// Attach the given source string for debug (e.g. the original input to `parse_formula`).
+    /// Used internally so that `Debug` and `debug_source()` show what was parsed.
+    pub fn set_debug_source(&mut self, source: impl Into<String>) {
+        self.source = Some(source.into());
+    }
+}
+
+impl fmt::Debug for ParsedFormula {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ParsedFormula")
+            .field(
+                "source",
+                &self.source.as_deref().unwrap_or("<not recorded>"),
+            )
+            .field("inner", &"<dyn Formula>")
+            .finish()
     }
 }
 
@@ -203,11 +244,17 @@ fn formula(input: &str) -> IResult<&str, ParsedFormula> {
 }
 
 pub fn parse_formula<'a>(input: &'a str) -> Result<ParsedFormula, Box<dyn Error + 'a>> {
-    let (rest, parsed) = formula(input)?;
+    let (rest, mut parsed) = formula(input)?;
 
     if !rest.is_empty() {
         Err(Box::new(IncompleteParseError::from(rest)))
     } else {
+        parsed.set_debug_source(input);
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[banquo_parser] parsed formula -> ParsedFormula {{ source: {:?} }}",
+            input
+        );
         Ok(parsed)
     }
 }

--- a/banquo-parser/src/parser/formula.rs
+++ b/banquo-parser/src/parser/formula.rs
@@ -63,10 +63,7 @@ impl ParsedFormula {
 impl fmt::Debug for ParsedFormula {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ParsedFormula")
-            .field(
-                "source",
-                &self.source.as_deref().unwrap_or("<not recorded>"),
-            )
+            .field("source", &self.source.as_deref().unwrap_or("<not recorded>"))
             .field("inner", &"<dyn Formula>")
             .finish()
     }

--- a/banquo-parser/src/parser/formula.rs
+++ b/banquo-parser/src/parser/formula.rs
@@ -130,6 +130,16 @@ fn predicate(input: &str) -> IResult<&str, Predicate> {
     Ok((rest, predicate))
 }
 
+/// Same syntax as `predicate`, but builds with `Predicate::new_standalone` so robustness
+/// is (right - left), matching `predicate!` when the formula is not under "and".
+fn predicate_standalone(input: &str) -> IResult<&str, Predicate> {
+    let mut parser = tuple((polynomial, op0("<="), polynomial));
+    let (rest, (left, _, right)) = parser(input)?;
+    let predicate = Predicate::new_standalone(left, right);
+
+    Ok((rest, predicate))
+}
+
 fn subformula(input: &str) -> IResult<&str, ParsedFormula> {
     let inner = delimited(space0, formula, space0);
     let mut parser = delimited(tag("("), inner, tag(")"));
@@ -156,6 +166,31 @@ fn right_operand(input: &str) -> IResult<&str, ParsedFormula> {
 /// Parse a full subformula, allowing optional surrounding whitespace.
 fn formula_operand(input: &str) -> IResult<&str, ParsedFormula> {
     delimited(space0, formula, space0)(input)
+}
+
+/// Operand parser for `always`/`eventually`: uses standalone predicate convention so
+/// formulas like `always 3.1*x <= 0.5*y` (no "and") match `predicate!` robustness.
+fn formula_operand_standalone(input: &str) -> IResult<&str, ParsedFormula> {
+    delimited(space0, formula_standalone, space0)(input)
+}
+
+/// Like `formula`, but bare predicates are built with `predicate_standalone` so they
+/// have robustness (right - left). Used as the body of `always`/`eventually`.
+fn formula_standalone(input: &str) -> IResult<&str, ParsedFormula> {
+    let mut parser = alt((
+        next,
+        always,
+        eventually,
+        not,
+        and,
+        or,
+        implies,
+        until,
+        subformula,
+        map(predicate_standalone, ParsedFormula::new),
+    ));
+
+    parser(input)
 }
 
 fn not(input: &str) -> IResult<&str, ParsedFormula> {
@@ -197,19 +232,17 @@ fn next(input: &str) -> IResult<&str, ParsedFormula> {
 }
 
 fn always(input: &str) -> IResult<&str, ParsedFormula> {
-    // `always` should apply to an arbitrary subformula, not just a single
-    // predicate. Using `formula_operand` here allows expressions like
-    // `always -0.785 <= roll and roll <= 0.785` to be parsed as
-    // `always ( (-0.785 <= roll) and (roll <= 0.785) )`.
-    let mut parser = operators::always(formula_operand);
+    // Use formula_operand_standalone so that a bare predicate (e.g. `always 3.1*x <= 0.5*y`)
+    // is built with the standalone convention and matches predicate!. Formulas with "and"
+    // still work: the "and" branch is tried first and its operands use predicate().
+    let mut parser = operators::always(formula_operand_standalone);
     let (rest, formula) = parser(input)?;
 
     Ok((rest, ParsedFormula::new(formula)))
 }
 
 fn eventually(input: &str) -> IResult<&str, ParsedFormula> {
-    // Same reasoning as `always`: allow compound subformulas after `eventually`.
-    let mut parser = operators::eventually(formula_operand);
+    let mut parser = operators::eventually(formula_operand_standalone);
     let (rest, formula) = parser(input)?;
 
     Ok((rest, ParsedFormula::new(formula)))

--- a/banquo-parser/tests/parse_against_reference.rs
+++ b/banquo-parser/tests/parse_against_reference.rs
@@ -1,0 +1,144 @@
+//! Integration test: parsed formula strings are compared to ground-truth reference
+//! formulas (built with `banquo::predicate!` and `Always::unbounded(And::new(...))`).
+//! Robustness must match on the same traces, proving the parser produces correct formulas.
+//!
+//! Run with: `cargo test -p banquo-parser --test parse_against_reference`
+
+use std::collections::HashMap;
+
+use banquo::operators::{Always, And};
+use banquo::{predicate, Formula as BanquoFormula};
+use banquo_parser::{parse_formula, ParsedFormula, Trace};
+
+type State = HashMap<String, f64>;
+
+fn min_robustness(metrics: &banquo_parser::Trace<f64>) -> f64 {
+    metrics
+        .iter()
+        .fold(f64::INFINITY, |acc, (_t, v)| if *v < acc { *v } else { acc })
+}
+
+/// Reference: Always(-π/4 <= roll and roll <= π/4)
+fn reference_roll_pi4() -> impl BanquoFormula<State, Metric = f64> {
+    let min_p: banquo::Predicate = predicate! { -0.78539816339 <= roll };
+    let max_p: banquo::Predicate = predicate! { roll <= 0.78539816339 };
+    Always::unbounded(And::new(min_p, max_p))
+}
+
+/// Reference: Always(-0.3 <= roll and roll <= 0.3)
+fn reference_roll_tight() -> impl BanquoFormula<State, Metric = f64> {
+    let min_p: banquo::Predicate = predicate! { -0.3 <= roll };
+    let max_p: banquo::Predicate = predicate! { roll <= 0.3 };
+    Always::unbounded(And::new(min_p, max_p))
+}
+
+/// Reference: Always(-0.5 <= roll_rate and roll_rate <= 0.5)
+fn reference_roll_rate() -> impl BanquoFormula<State, Metric = f64> {
+    let min_p: banquo::Predicate = predicate! { -0.5 <= roll_rate };
+    let max_p: banquo::Predicate = predicate! { roll_rate <= 0.5 };
+    Always::unbounded(And::new(min_p, max_p))
+}
+
+/// Reference: Always(3.1*x <= 0.5*y) — single predicate (no "and")
+fn reference_linear_xy() -> impl BanquoFormula<State, Metric = f64> {
+    Always::unbounded(predicate! { 3.1 * x <= 0.5 * y })
+}
+
+fn ref_robustness(idx: usize, t: &Trace<State>) -> f64 {
+    match idx {
+        0 => min_robustness(&reference_roll_pi4().evaluate(t).unwrap_or_else(|_| panic!("ref 0"))),
+        1 => min_robustness(&reference_roll_tight().evaluate(t).unwrap_or_else(|_| panic!("ref 1"))),
+        2 => min_robustness(&reference_roll_rate().evaluate(t).unwrap_or_else(|_| panic!("ref 2"))),
+        3 => min_robustness(&reference_linear_xy().evaluate(t).unwrap_or_else(|_| panic!("ref 3"))),
+        _ => panic!("ref index out of range"),
+    }
+}
+
+fn state(roll: f64, pitch: f64, roll_rate: f64, lateral_accel: f64) -> State {
+    HashMap::from([
+        ("roll".into(), roll),
+        ("pitch".into(), pitch),
+        ("roll_rate".into(), roll_rate),
+        ("lateral_accel".into(), lateral_accel),
+    ])
+}
+
+fn xy_state(x: f64, y: f64) -> State {
+    HashMap::from([("x".into(), x), ("y".into(), y)])
+}
+
+#[test]
+fn parsed_formulas_match_reference_on_traces() {
+    const TOL: f64 = 1e-9;
+
+    // Each entry: (formula string, index into reference formula)
+    let formulas: [(&str, usize); 4] = [
+        (
+            "always -0.78539816339 <= roll and roll <= 0.78539816339",
+            0,
+        ),
+        ("always -0.3 <= roll and roll <= 0.3", 1),
+        ("always -0.5 <= roll_rate and roll_rate <= 0.5", 2),
+        ("always 3.1*x <= 0.5*y", 3),
+    ];
+
+    let trace_in_bounds: Trace<State> = Trace::from([
+        (0.0, state(0.0, 0.0, 0.0, 0.0)),
+        (1.0, state(0.2, 0.0, 0.2, 0.0)),
+    ]);
+
+    let trace_xy_ok: Trace<State> =
+        Trace::from([(0.0, xy_state(0.1, 1.0)), (1.0, xy_state(0.2, 2.0))]);
+    let trace_xy_violate: Trace<State> = Trace::from([(0.0, xy_state(1.0, 0.1))]);
+
+    let trace_violations: [Trace<State>; 4] = [
+        Trace::from([(0.0, state(1.0, 0.0, 0.0, 0.0))]),
+        Trace::from([(0.0, state(0.5, 0.0, 0.0, 0.0))]),
+        Trace::from([(0.0, state(0.0, 0.0, 1.0, 0.0))]),
+        trace_xy_violate.clone(),
+    ];
+
+    for (src, ref_idx) in formulas {
+        let parsed: ParsedFormula = parse_formula(src).unwrap_or_else(|e| {
+            panic!("parse formula {:?}: {}", src, e);
+        });
+
+        let (trace_ok, trace_v) = if ref_idx == 3 {
+            (&trace_xy_ok, &trace_xy_violate)
+        } else {
+            (&trace_in_bounds, &trace_violations[ref_idx])
+        };
+
+        let ref_r = ref_robustness(ref_idx, trace_ok);
+        let parsed_r = min_robustness(&parsed.evaluate(trace_ok).expect("parsed eval"));
+        assert!(
+            (ref_r - parsed_r).abs() < TOL,
+            "formula {:?}: in-bounds trace: reference={}, parsed={}",
+            src,
+            ref_r,
+            parsed_r
+        );
+        assert!(
+            ref_r >= 0.0,
+            "formula {:?}: in-bounds should have non-negative robustness; got {}",
+            src,
+            ref_r
+        );
+
+        let ref_rv = ref_robustness(ref_idx, trace_v);
+        let parsed_rv = min_robustness(&parsed.evaluate(trace_v).expect("parsed eval"));
+        assert!(
+            (ref_rv - parsed_rv).abs() < TOL,
+            "formula {:?}: violating trace: reference={}, parsed={}",
+            src,
+            ref_rv,
+            parsed_rv
+        );
+        assert!(
+            ref_rv < 0.0,
+            "formula {:?}: violating trace should have negative robustness; got {}",
+            src,
+            ref_rv
+        );
+    }
+}

--- a/banquo-parser/tests/parse_against_reference.rs
+++ b/banquo-parser/tests/parse_against_reference.rs
@@ -73,22 +73,16 @@ fn parsed_formulas_match_reference_on_traces() {
 
     // Each entry: (formula string, index into reference formula)
     let formulas: [(&str, usize); 4] = [
-        (
-            "always -0.78539816339 <= roll and roll <= 0.78539816339",
-            0,
-        ),
+        ("always -0.78539816339 <= roll and roll <= 0.78539816339", 0),
         ("always -0.3 <= roll and roll <= 0.3", 1),
         ("always -0.5 <= roll_rate and roll_rate <= 0.5", 2),
         ("always 3.1*x <= 0.5*y", 3),
     ];
 
-    let trace_in_bounds: Trace<State> = Trace::from([
-        (0.0, state(0.0, 0.0, 0.0, 0.0)),
-        (1.0, state(0.2, 0.0, 0.2, 0.0)),
-    ]);
+    let trace_in_bounds: Trace<State> =
+        Trace::from([(0.0, state(0.0, 0.0, 0.0, 0.0)), (1.0, state(0.2, 0.0, 0.2, 0.0))]);
 
-    let trace_xy_ok: Trace<State> =
-        Trace::from([(0.0, xy_state(0.1, 1.0)), (1.0, xy_state(0.2, 2.0))]);
+    let trace_xy_ok: Trace<State> = Trace::from([(0.0, xy_state(0.1, 1.0)), (1.0, xy_state(0.2, 2.0))]);
     let trace_xy_violate: Trace<State> = Trace::from([(0.0, xy_state(1.0, 0.1))]);
 
     let trace_violations: [Trace<State>; 4] = [


### PR DESCRIPTION
Use (right - left) instead of (left - right) so robustness is non-negative when the inequality holds